### PR TITLE
Increase timeout settings for HubOptions

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,8 +8,8 @@ builder.Services.AddRazorComponents().AddInteractiveServerComponents()
     .AddHubOptions(options =>
 {
     // These settings prevent "Attempting to reconnect to server..." modal messages from popping up.
-    options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-    options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(90);
+    options.HandshakeTimeout = TimeSpan.FromSeconds(60);
 });
     
 builder.Services.AddScoped<StateContainer>();


### PR DESCRIPTION
resolves #22

First PR worked for local development but not production. This now works as intended.

Adjust timeout settings to reduce the frequency of reconnection modal messages.