### PR TITLE
fix: remove reconnect modal and update documentation links for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ $RECYCLE.BIN/
 .DS_Store
 
 _NCrunch*
+
+# Specific ignores
+*.html

--- a/Components/App.razor
+++ b/Components/App.razor
@@ -20,6 +20,8 @@
 
 <body>
     <Routes />
+    @* Removes the 'attempting to reconnect...' modal *@
+    <div id="components-reconnect-modal"></div>
     <script src="_framework/blazor.web.js"></script>
     <script>
         Blazor.start({

--- a/Components/Custom/DocLink.razor
+++ b/Components/Custom/DocLink.razor
@@ -10,7 +10,7 @@
 @namespace Components.Custom
 
 <div class="col-xl-3 col-lg-3 col-md-6 col-sm-12  g-2">
-    <div class="card card-hover-shadow" @onclick="GetDocString">
+    <div class="card card-hover-shadow">
         <NavLink class="nav-link" href="@DocLinkHref">
             <img class="d-block mx-auto" src="Wheat.svg" alt="wheat image" width="25"/>
             <div class="card-body">
@@ -36,12 +36,5 @@
     [Parameter]
     public string? DocLinkHref {get; set;}
 
-    public void GetDocString()
-    {
-        @* TODO: Replace hard coded ApsimX assembly reference.  *@
-        using StreamReader reader = new("./" + DocModelName + ".html");
-        string docString = reader.ReadToEnd();
-        StateContainer.ApsimDocString = docString;
-    } 
 } 
 

--- a/Components/Layout/MainLayout.razor
+++ b/Components/Layout/MainLayout.razor
@@ -12,8 +12,3 @@
     </main>
 </div>
 
-<div id="blazor-error-ui">
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
-</div>

--- a/Components/Layout/TutLinks.razor
+++ b/Components/Layout/TutLinks.razor
@@ -5,49 +5,49 @@
     <div class="row">
         <DocLink DocModelName="ClimateController" 
             DocDisplayName="Climate Controller"
-            DocLinkHref="tutorial/climate control"
+            DocLinkHref="tutorial/ClimateController"
             DocDescript="Usage of climate control manager component.">
         </DocLink> 
 
         <DocLink DocModelName="Lifecycle" 
             DocDisplayName="Lifecycle"
-            DocLinkHref="tutorial/lifecycle"
+            DocLinkHref="tutorial/Lifecycle"
             DocDescript="Describes managing the lifecycle of a pseudoaphid.">
         </DocLink> 
 
         <DocLink DocModelName="Manager" 
             DocDisplayName="Manager"
-            DocLinkHref="tutorial/manager"
+            DocLinkHref="tutorial/Manager"
             DocDescript="Provides two tutorials covering sowing fertiliser topup and water and N topup rules.">
         </DocLink> 
 
         <DocLink DocModelName="Sensitivity_MorrisMethod"
             DocDisplayName="Parameter sensitivity (Morris)"
-            DocLinkHref="tutorial/morris"
+            DocLinkHref="tutorial/Sensitivity_MorrisMethod"
             DocDescript="Describes the process of using the Morris method for parameter sensitivity analysis.">
         </DocLink> 
 
         <DocLink DocModelName="Sensitivity_SobolMethod"
             DocDisplayName="Parameter sensitivity (SOBOL)"
-            DocLinkHref="tutorial/sobol"
+            DocLinkHref="tutorial/Sensitivity_SobolMethod"
             DocDescript="Describes the process of using the SOBOL method for parameter sensitivity analysis.">
         </DocLink> 
 
         <DocLink DocModelName="Sensitivity_FactorialANOVA"
             DocDisplayName="Parameter sensitivity (Factorial ANOVA)" 
-            DocLinkHref="tutorial/anova"
+            DocLinkHref="tutorial/Sensitivity_FactorialANOVA"
             DocDescript="Describes the process of using the Factorial ANOVA method for parameter sensitivity analysis.">
         </DocLink> 
 
         <DocLink DocModelName="PredictedObserved"
             DocDisplayName="Predicted/Observed Data Handling"
-            DocLinkHref="tutorial/predobs"
+            DocLinkHref="tutorial/PredictedObserved"
             DocDescript="Describes the process of predicted/observed data handling for fitting plant models.">
         </DocLink> 
 
         <DocLink DocModelName="Report" 
             DocDisplayName="Report"
-            DocLinkHref="tutorial/report"
+            DocLinkHref="tutorial/Report"
             DocDescript="Provides tutorials and instruction on how to use the Report model.">
         </DocLink> 
 
@@ -59,13 +59,13 @@
 
         <DocLink DocModelName="CLEM_Example_Cropping" 
             DocDisplayName="CLEM Cropping Examples"
-            DocLinkHref="doc/CLEM Examples"
+            DocLinkHref="doc/CLEM_Example_Cropping"
             DocDescript="Setting up cropping simulations">
         </DocLink> 
 
         <DocLink DocModelName="CLEM_Example_Grazing" 
             DocDisplayName="CLEM Grazing Example"
-            DocLinkHref="doc/CLEM Grazing Example"
+            DocLinkHref="doc/CLEM_Example_Grazing"
             DocDescript="CLEM grazing simulation example">
         </DocLink> 
     </div>

--- a/Components/Pages/Doc.razor
+++ b/Components/Pages/Doc.razor
@@ -71,7 +71,7 @@ else
     private void SetCSS()
     {
         if (StateContainer.CssString != null)
-        {
+        { 
             MarkupString markupDocString = new(StateContainer.CssString);
             cssString = markupDocString;
         }        
@@ -84,13 +84,30 @@ else
 
     private void GetApsimDocString()
     {
-        if (StateContainer.ApsimDocString != null)
+        MarkupString markupDocString;
+        string initialApsimDocString = "";
+
+        // Get the html doc string from the local file system.
+        string currentDir = Directory.GetCurrentDirectory();
+        string apsimxFile = Path.Combine(currentDir,filename!+".html");
+        if (File.Exists(Path.Combine(apsimxFile)))
         {
-            string initialApsimDocString = StateContainer.ApsimDocString;
+            initialApsimDocString = File.ReadAllText(apsimxFile);
             string linkModifiedApsimDocString = initialApsimDocString.Replace("href=\"#",$"href=\"{NavigationManager.Uri}#");
-            MarkupString markupDocString = new(linkModifiedApsimDocString);
+            markupDocString = new(linkModifiedApsimDocString);
             docString = markupDocString;
         }
+        else
+        {
+            markupDocString = new(
+                "<div class=\"container\">"+
+                "<div class=\"row\"><span class=\"col\">The document you selected is currently unavailable. Please submit an issue.</span></div>" +
+                "<div class=\"row\"><span class=\"col\"><a target=\"_blank\" href=\"https://github.com/APSIMInitiative/APSIM.Docs/issues\">APSIM.Docs issues</a></span></div>"+
+                "</div>"
+            );
+            docString = markupDocString;
+        }
+
     }
 
 }

--- a/Components/Pages/Tutorial.razor
+++ b/Components/Pages/Tutorial.razor
@@ -84,13 +84,30 @@ else
 
     private void GetApsimDocString()
     {
-        if (StateContainer.ApsimDocString != null)
+        MarkupString markupDocString;
+        string initialApsimDocString = "";
+
+        // Get the html doc string from the local file system.
+        string currentDir = Directory.GetCurrentDirectory();
+        string apsimxFile = Path.Combine(currentDir,filename!+".html");
+        if (File.Exists(Path.Combine(apsimxFile)))
         {
-            string initialApsimDocString = StateContainer.ApsimDocString;
+            initialApsimDocString = File.ReadAllText(apsimxFile);
             string linkModifiedApsimDocString = initialApsimDocString.Replace("href=\"#",$"href=\"{NavigationManager.Uri}#");
-            MarkupString markupDocString = new(linkModifiedApsimDocString);
+            markupDocString = new(linkModifiedApsimDocString);
             docString = markupDocString;
         }
+        else
+        {
+            markupDocString = new(
+                "<div class=\"container\">"+
+                "<div class=\"row\"><span class=\"col\">The document you selected is currently unavailable. Please submit an issue.</span></div>" +
+                "<div class=\"row\"><span class=\"col\"><a target=\"_blank\" href=\"https://github.com/APSIMInitiative/APSIM.Docs/issues\">APSIM.Docs issues</a></span></div>"+
+                "</div>"
+            );
+            docString = markupDocString;
+        }
+
     }
 
 }

--- a/Components/Pages/Tutorials.razor
+++ b/Components/Pages/Tutorials.razor
@@ -9,7 +9,3 @@
 <h1>Tutorials</h1>
 
 <TutLinks/>
-
-@code{
-@* put nav code for tutorials here. *@
-}

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -49,3 +49,8 @@ h1:focus {
 .darker-border-checkbox.form-check-input {
     border-color: #929292;
 }
+
+/* Required to remove 'attempting to reconnect..' modal */
+.components-reconnect-show, .components-reconnect-failed, .components-reconnect-rejected {
+    display: none;
+}


### PR DESCRIPTION
resolves #26

# Notes

- attempting to connect modal is now removed.
- APSIM.Docs now always uses the local HTML that's created at container/application start rather than loading html into state storage. This means that users can share links to specific docs and tutorials.
- Links are now corrected so they work with the new HTML loading method.
