### PR TITLE
feat: allow docker image workflow to run manually

### DIFF
--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -13,6 +13,7 @@ on:
   pull_request_target:
     types:
       - closed
+  workflow_dispatch:
 
 jobs:
   if_merged:


### PR DESCRIPTION
working on #33

Attempt at manual github workflow button for generating docker image