### PR TITLE
Nightly docker image builds

### DIFF
--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -14,6 +14,8 @@ on:
     types:
       - closed
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   if_merged:


### PR DESCRIPTION
resolves #35

The github workflow yml now specifies a schedule for building a docker image. This is one part of making sure that APSIM.Docs remains up-to-date.