### PR TITLE
Make paths docker friendly

### DIFF
--- a/Components/Pages/Models.razor
+++ b/Components/Pages/Models.razor
@@ -86,10 +86,12 @@ else
     {
         MarkupString markupDocString;
         string initialApsimDocString = "";
+        string docHtmlDirName = "/apsim-docs-html/";
+
 
         // Get the html doc string from the local file system.
         string currentDir = Directory.GetCurrentDirectory();
-        string apsimxFile = Path.Combine(currentDir,filename!+".html");
+        string apsimxFile = Path.Combine(currentDir + docHtmlDirName,filename!+".html");
         if (File.Exists(Path.Combine(apsimxFile)))
         {
             initialApsimDocString = File.ReadAllText(apsimxFile);

--- a/Components/Pages/Tutorial.razor
+++ b/Components/Pages/Tutorial.razor
@@ -86,10 +86,11 @@ else
     {
         MarkupString markupDocString;
         string initialApsimDocString = "";
+        string docHtmlDirName = "/apsim-docs-html/";
 
         // Get the html doc string from the local file system.
         string currentDir = Directory.GetCurrentDirectory();
-        string apsimxFile = Path.Combine(currentDir,filename!+".html");
+        string apsimxFile = Path.Combine(currentDir + docHtmlDirName,filename!+".html");
         if (File.Exists(Path.Combine(apsimxFile)))
         {
             initialApsimDocString = File.ReadAllText(apsimxFile);

--- a/Components/Pages/Validation.razor
+++ b/Components/Pages/Validation.razor
@@ -86,10 +86,11 @@ else
     {
         MarkupString markupDocString;
         string initialApsimDocString = "";
+        string docHtmlDirName = "/apsim-docs-html/";
 
         // Get the html doc string from the local file system.
         string currentDir = Directory.GetCurrentDirectory();
-        string apsimxFile = Path.Combine(currentDir,filename!+".html");
+        string apsimxFile = Path.Combine(currentDir + docHtmlDirName,filename!+".html");
         if (File.Exists(Path.Combine(apsimxFile)))
         {
             initialApsimDocString = File.ReadAllText(apsimxFile);


### PR DESCRIPTION
resolves #46

The paths for card links are now changed to point to the docker volume bind mount location